### PR TITLE
Bumped to 1.5.11. Install example config in correct location.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,5 +8,5 @@ To Build:
     sudo yum -y install rpmdevtools && rpmdev-setuptree
     sudo yum -y install pcre-devel gcc make openssl-devel
     wget https://raw.github.com/nmilford/rpm-haproxy/master/haproxy.spec -O ~/rpmbuild/SPECS/haproxy.spec
-    wget http://www.haproxy.org/download/1.5/src/haproxy-1.5.10.tar.gz -O ~/rpmbuild/SOURCES/haproxy-1.5.10.tar.gz
-    rpmbuild -bb  ~/rpmbuild/SPECS/haproxy.spec --define "release 1"
+    wget http://www.haproxy.org/download/1.5/src/haproxy-1.5.11.tar.gz -O ~/rpmbuild/SOURCES/haproxy-1.5.11.tar.gz
+    rpmbuild -bb ~/rpmbuild/SPECS/haproxy.spec --define "release 1"

--- a/haproxy.spec
+++ b/haproxy.spec
@@ -3,10 +3,10 @@
 # sudo yum -y install rpmdevtools && rpmdev-setuptree
 # sudo yum -y install pcre-devel gcc make
 # wget https://raw.github.com/nmilford/rpm-haproxy/master/haproxy.spec -O ~/rpmbuild/SPECS/haproxy.spec
-# wget http://www.haproxy.org/download/1.5/src/haproxy-1.5.10.tar.gz -O ~/rpmbuild/SOURCES/haproxy-1.5.10.tar.gz
-# rpmbuild -bb  ~/rpmbuild/SPECS/haproxy.spec
+# wget http://www.haproxy.org/download/1.5/src/haproxy-1.5.11.tar.gz -O ~/rpmbuild/SOURCES/haproxy-1.5.11.tar.gz
+# rpmbuild -bb ~/rpmbuild/SPECS/haproxy.spec
 
-%define version 1.5.10
+%define version 1.5.11
 %{!?release: %{!?release: %define release 1}}
 
 Summary: HA-Proxy is a TCP/HTTP reverse proxy for high availability environments
@@ -60,7 +60,7 @@ mkdir -p %{buildroot}/usr/share/haproxy
 cp examples/errorfiles/503.http %{buildroot}/etc/haproxy/errors/503.http
 
 %{__install} -s %{name} %{buildroot}%{_sbindir}/
-%{__install} -c -m 644 examples/%{name}.cfg %{buildroot}%{_sysconfdir}/%{name}/
+%{__install} -c -m 644 examples/%{name}.cfg %{buildroot}%{_sysconfdir}/%{name}/%{name}.cfg.example
 %{__install} -c -m 755 examples/%{name}.init %{buildroot}%{_sysconfdir}/rc.d/init.d/%{name}
 %{__install} -c -m 755 doc/%{name}.1 %{buildroot}%{_mandir}/man1/
 
@@ -95,12 +95,15 @@ fi
 
 %attr(0755,root,root) %{_sbindir}/%{name}
 %dir %{_sysconfdir}/%{name}
-%attr(0644,root,root) %config(noreplace) %{_sysconfdir}/%{name}/%{name}.cfg
+%attr(0644,root,root) %{_sysconfdir}/%{name}/%{name}.cfg.example
 %attr(0755,root,root) %config %{_sysconfdir}/rc.d/init.d/%{name}
 
 %attr(0755,haproxy,haproxy) %{_sharedstatedir}/haproxy
 
 %changelog
+* Wed Apr 08 2015 David Wooldridge <zombie@zombix.org>
+- updated to 1.5.11
+
 * Sat Jan 03 2015 Jonathan Mainguy <jon@soh.re>
 - updated to 1.5.10
 


### PR DESCRIPTION
I think the example config should be installed in the config directory but not as the service's configuration, so install it as haproxy.cfg.example instead of haproxy.cfg.